### PR TITLE
Sepolicy: fix build errors

### DIFF
--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -4,3 +4,5 @@ type sysfs_display, fs_type, sysfs_type;
 type sysfs_sec, fs_type, sysfs_type;
 type sysfs_vibeamp, fs_type, sysfs_type;
 type wifi_efs_file, file_type;
+type macloader, domain;
+type macloader_exec, exec_type, file_type;

--- a/sepolicy/macloader.te
+++ b/sepolicy/macloader.te
@@ -1,5 +1,3 @@
-type macloader, domain;
-type macloader_exec, exec_type, file_type;
 init_daemon_domain(macloader)
 
 allow macloader efs_file:file rw_file_perms;

--- a/sepolicy/property.te
+++ b/sepolicy/property.te
@@ -1,0 +1,1 @@
+type qseecomd_prop, property_type;


### PR DESCRIPTION
Apparently defining the type right along with the policy breaks the build.  I've made these two commits to fix build errors I was getting by defining the new type's outside of the policy addition.
